### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/imgcaption.php
+++ b/syntax/imgcaption.php
@@ -84,7 +84,7 @@ class syntax_plugin_imagereference_imgcaption extends DokuWiki_Syntax_Plugin {
      * @param Doku_Handler    $handler The handler
      * @return array Data for the renderer
      */
-    public function handle($match, $state, $pos, Doku_Handler &$handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         global $ACT;
         switch($state) {
             case DOKU_LEXER_ENTER :
@@ -126,7 +126,7 @@ class syntax_plugin_imagereference_imgcaption extends DokuWiki_Syntax_Plugin {
      * @param array          $indata    The data from the handler function
      * @return bool If rendering was successful.
      */
-    public function render($mode, Doku_Renderer &$renderer, $indata) {
+    public function render($mode, Doku_Renderer $renderer, $indata) {
         global $ID, $ACT;
         list($case, $data) = $indata;
 

--- a/syntax/imgref.php
+++ b/syntax/imgref.php
@@ -56,7 +56,7 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
      * @param Doku_Handler    $handler The handler
      * @return array Data for the renderer
      */
-    function handle($match, $state, $pos, Doku_Handler &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $reftype = substr($match, 1, 3);
         $ref = substr($match, 7, -1);
 
@@ -86,7 +86,7 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
      * @param array          $data      The data from the handler function
      * @return bool If rendering was successful.
      */
-    function render($mode, Doku_Renderer &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         global $ID, $ACT;
         if($data === false) return false;
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.