### PR TITLE
Add support for GeoGebrEmbed

### DIFF
--- a/lang/de-informal/lang.php
+++ b/lang/de-informal/lang.php
@@ -5,7 +5,9 @@
  * 
  * @author Sebastian Klemm <sebastian_klemm@freenet.de>
  */
-$lang['imgshort']              = 'Abb.';
-$lang['tabshort']              = 'Tab.';
-$lang['imgfull']               = 'Abbildung';
-$lang['tabfull']               = 'Tabelle';
+$lang['imgshort'] = 'Abb.';
+$lang['tabshort'] = 'Tab.';
+$lang['ggbshort'] = 'GeoGebra';
+$lang['imgfull']  = 'Abbildung';
+$lang['tabfull']  = 'Tabelle';
+$lang['ggbfull']  = 'GeoGebra-Applet';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -5,5 +5,7 @@
 
 $lang['imgshort'] = 'Abb.';
 $lang['tabshort'] = 'Tab.';
+$lang['ggbshort'] = 'GeoGebra';
 $lang['imgfull']  = 'Abbildung';
 $lang['tabfull']  = 'Tabelle';
+$lang['ggbfull']  = 'GeoGebra-Applet';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -5,5 +5,7 @@
 
 $lang['imgshort'] = 'Fig.';
 $lang['tabshort'] = 'Tab.';
+$lang['ggbshort'] = 'GeoGebra';
 $lang['imgfull']  = 'figure';
 $lang['tabfull']  = 'table';
+$lang['ggbfull']  = 'GeoGebra applet';

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -5,5 +5,7 @@
 
 $lang['imgshort'] = 'Fig.';
 $lang['tabshort'] = 'Tab.';
+$lang['ggbshort'] = 'GeoGebra';
 $lang['imgfull']  = 'figure';
 $lang['tabfull']  = 'table';
+$lang['ggbfull']  = 'application GeoGebra';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   imagereference
 author Gerrit Uitslag (previous: Martin Heinemann)
 email  klapinklapin@gmail.com, info@martinheinemann.net
-date   2020-12-13
+date   2021-10-18
 name   imagereference plugin
 desc   Creates references to images/tables in your text, like the LaTeX figure references.
 url    https://www.dokuwiki.org/plugin:imagereference

--- a/style.css
+++ b/style.css
@@ -31,6 +31,7 @@ div.tabcaptionbox.center {
 
 /* ggb caption */
 div.ggbcaption {
+    margin-bottom: 10px;
     border: 1px solid #ccc;
     padding: 3px !important;
     background-color: #f9f9f9;  
@@ -44,7 +45,7 @@ div.ggbcaption {
 
 /* ggb caption */
 div.ggbcaption.center {
-    margin: 1px auto;
+    margin: 1px auto 10px;
 }
 
 /* image caption */

--- a/style.css
+++ b/style.css
@@ -29,6 +29,24 @@ div.tabcaptionbox.center {
 }
 */
 
+/* ggb caption */
+div.ggbcaption {
+    border: 1px solid #ccc;
+    padding: 3px !important;
+    background-color: #f9f9f9;  
+    font-size: 94%;
+    text-align: center;
+    width: auto;
+    overflow: hidden;
+    float: none;
+    display: table;
+}
+
+/* ggb caption */
+div.ggbcaption.center {
+    margin: 1px auto;
+}
+
 /* image caption */
 span.imgcaption {
     border: 1px solid #ccc;

--- a/syntax/ggbcaption.php
+++ b/syntax/ggbcaption.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Plugin imagereference
+ *
+ * Syntax: <tabref linkname> - creates a table link to a table
+ *         <tabcaption linkname <orientation> | Table caption> Table</tabcaption>
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Gerrit Uitslag <klapinklapin@gmail.com>
+ * @author     Philipp Imhof <dev@imhof.cc>
+ */
+
+if(!defined('DOKU_INC')) die();
+
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_imagereference_ggbcaption extends syntax_plugin_imagereference_imgcaption {
+
+    /**
+     * @return string Syntax type
+     */
+    public function getType() {
+        return 'formatting';
+    }
+    /**
+     * @return string Paragraph type
+     */
+    public function getPType() {
+        return 'block';
+    }
+    /**
+     * @return int Sort order
+     */
+    public function getSort() {
+        return 196;
+    }
+
+    /**
+     * Specify modes allowed in the ggbcaption tag
+     * Using getAllowedTypes() includes too much modes.
+     *
+     * @param string $mode Parser mode
+     * @return bool true if $mode is accepted
+     */
+    public function accepts($mode) {
+        $allowedsinglemodes = array(
+            'media', //allowed content
+            'plugin_geogebrembed_ggb'    //plugins
+        );
+        if(in_array($mode, $allowedsinglemodes)) return true;
+        
+        return parent::accepts($mode);
+    }
+
+    /**
+     * Connect lookup pattern to lexer.
+     *
+     * @param string $mode Parser mode
+     */
+    public function connectTo($mode) {
+        $this->Lexer->addEntryPattern('<ggbcaption.*?>(?=.*?</ggbcaption>)', $mode, 'plugin_imagereference_ggbcaption');
+    }
+
+    public function postConnect() {
+        $this->Lexer->addExitPattern('</ggbcaption>', 'plugin_imagereference_ggbcaption');
+    }
+
+}
+

--- a/syntax/ggbcaption.php
+++ b/syntax/ggbcaption.php
@@ -67,5 +67,12 @@ class syntax_plugin_imagereference_ggbcaption extends syntax_plugin_imagereferen
         $this->Lexer->addExitPattern('</ggbcaption>', 'plugin_imagereference_ggbcaption');
     }
 
+    /**
+     * @var string $captionStart opening tag of caption
+     * @var string $captionEnd closing tag of caption
+     */
+    protected $captionStart = '<div id="%s" class="ggbcaption%s">';
+    protected $captionEnd   = '</div>';
+
 }
 

--- a/syntax/imgcaption.php
+++ b/syntax/imgcaption.php
@@ -185,6 +185,10 @@ class syntax_plugin_imagereference_imgcaption extends DokuWiki_Syntax_Plugin {
             case 'latex' :
                 if($data['type'] == 'img') {
                     $floattype = 'figure';
+                }
+                else if ($data['type'] == 'ggb') {
+                    // no latex support for GeoGebra applets
+                    return true;
                 } else {
                     $floattype = 'table';
                 }

--- a/syntax/imgref.php
+++ b/syntax/imgref.php
@@ -8,6 +8,7 @@
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Martin Heinemann <info@martinheinemann.net>
  * @author     Gerrit Uitslag <klapinklapin@gmail.com>
+ * @author     Philipp Imhof <dev@imhof.cc>
  */
 
 
@@ -44,6 +45,7 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
     function connectTo($mode) {
         $this->Lexer->addSpecialPattern('<imgref.*?>', $mode, 'plugin_imagereference_imgref');
         $this->Lexer->addSpecialPattern('<tabref.*?>', $mode, 'plugin_imagereference_imgref');
+        $this->Lexer->addSpecialPattern('<ggbref.*?>', $mode, 'plugin_imagereference_imgref');
     }
     /**
      * Handle matches of the imgref syntax


### PR DESCRIPTION
The GeoGebrEmbed plugin allows easy embedding of GeoGebra applets into DokuWiki pages. These changes add a new `<ggbcaption>` tag along with `<ggbref>` to add support for captions and links to embedded applets.